### PR TITLE
Avoid type piracy with DynamicPolynomials

### DIFF
--- a/src/MultivariateSeries.jl
+++ b/src/MultivariateSeries.jl
@@ -32,12 +32,4 @@ function DynamicPolynomials.MonomialVector(V::Vector{PolyVar{true}}, rg::Seq)
      L
 end
 
-function DynamicPolynomials.MonomialVector(V::Vector{PolyVar{true}}, rg::UnitRange{Int64})
-     L = DynamicPolynomials.Monomial{true}[]
-     for i in rg
-         append!(L, DynamicPolynomials.monomials(V,i))
-     end
-     L
-end
-
 end


### PR DESCRIPTION
This method is what is called "type piracy" as it is a method of a function defined outside this package with argument types defined outside this package.
Such methods changes the behavior of code not using this package just by doing `using MultivariateSeries`.
It actually broke SumOfSquares for this reason : https://github.com/jump-dev/SumOfSquares.jl/pull/216

In fact the code seems to use the method above which is not type piracy since one of the argument has type `Seq` which is defined in this package.