### PR TITLE
Fix support for 32-bit by using Int instead of Int64

### DIFF
--- a/src/decompose.jl
+++ b/src/decompose.jl
@@ -9,7 +9,7 @@ eps_rkf = eps::Float64 -> function (S)
   i-1;
 end
 
-cst_rkf = r::Int64 -> function (S) return r end
+cst_rkf = r::Int -> function (S) return r end
 
 #------------------------------------------------------------------------
 # Decomposition of the pencil of matrices

--- a/src/moments.jl
+++ b/src/moments.jl
@@ -51,7 +51,7 @@ end
 #----------------------------------------------------------------------
 """
 ```
-moment(w::Vector{C}, P::Matrix{C}) -> Vector{Int64} -> C
+moment(w::Vector{C}, P::Matrix{C}) -> Vector{Int} -> C
 ```
 Compute the moment function ``α -> ∑_{i} ω_{i} P_{i}^α``
 associated to the sequence P of r points of dimension n, which is a matrix
@@ -88,7 +88,7 @@ end
 #----------------------------------------------------------------------
 """
 ```
-moment(p::Polynomial, zeta::Vector{C}) -> Vector{Int64} -> C
+moment(p::Polynomial, zeta::Vector{C}) -> Vector{Int} -> C
 ```
 Compute the moment function ``α \\rightarrow p(ζ^α)``.
 """
@@ -111,11 +111,11 @@ end
 #----------------------------------------------------------------------
 """
 ```
-series(w:: Vector{C}, P::AbstractMatrix, X, d::Int64) -> Series{C,M}
+series(w:: Vector{C}, P::AbstractMatrix, X, d::Int) -> Series{C,M}
 ```
 Compute the series of the moment sequence ``∑_i ω_{i} P_{i}^α`` for ``|α| \\leq d``.
 """
-function series(w::Vector{C}, P::AbstractMatrix, X, d::Int64) where C
+function series(w::Vector{C}, P::AbstractMatrix, X, d::Int) where C
     h = moment(w,P)
     L = monomials(X,seq(0:d))
    series(h,L)
@@ -125,11 +125,11 @@ end
 #----------------------------------------------------------------------
 """
 ```
-series(p::Polynomial, zeta, X, d::Int64) -> Series
+series(p::Polynomial, zeta, X, d::Int) -> Series
 ```
 Compute the series of moments ``p(ζ^α)`` for ``|α| \\leq d``.
 """
-function series(p::Polynomial, zeta, X, d::Int64)
+function series(p::Polynomial, zeta, X, d::Int)
     h = moment(p,zeta)
     L = monomials(X,seq(0:d))
     series(h,L)
@@ -142,14 +142,14 @@ sparse_pol(w, E, X) -> Polynomial{true,C}
 ```
 Compute the polynomial ``∑ ωᵢ X^E[i,:]`` with coefficients ``ωᵢ`` and monomial exponents ``E[i,:]``.
 """
-function sparse_pol(w::Vector, E::Matrix{Int64}, X)
+function sparse_pol(w::Vector, E::Matrix{Int}, X)
     sum(w[j]*prod(X[i]^E[j,i] for i in 1:size(E,2)) for j in 1:length(w))
 end
 
 
 
 #------------------------------------------------------------------------
-function sparse_decompose(f, zeta, X, d:: Int64)
+function sparse_decompose(f, zeta, X, d:: Int)
     sigma = series(moment(f,zeta), monomials(X,seq(0:d)))
     w, Xi = decompose(sigma)
     w, log(Xi,zeta)

--- a/src/newton.jl
+++ b/src/newton.jl
@@ -62,7 +62,7 @@ end
 #----------------------------------------------------------------------
 function vdm_newton(w0, Xi0, s0, L;  args...)
     eps::Float64 = 1.e-5
-    cmax::Int64  = 10
+    cmax::Int  = 10
     for arg in args
         if arg[1]==:maxit
             cmax=arg[2]

--- a/src/polynomials.jl
+++ b/src/polynomials.jl
@@ -29,7 +29,7 @@ end
 #----------------------------------------------------------------------
 """
 ```
-deg(p:Polynomial) -> Int64
+deg(p:Polynomial) -> Int
 ```
 Degree of a polynomial
 """
@@ -65,9 +65,9 @@ end
 #----------------------------------------------------------------------
 """
 ```
-exponent(m::Monomial) -> Array{Int64,1}
+exponent(m::Monomial) -> Array{Int,1}
 ```
-Get the exponent of a monomial as an array of Int64
+Get the exponent of a monomial as an array of Int
 """
 function Base.exponent(m::Monomial)
     return m.z
@@ -109,13 +109,13 @@ end
 #-----------------------------------------------------------------------
 """
 ```
-monoms(V, d::Int64) -> Vector{Monomial}
-monoms(V, rg::UnitRangeInt64) -> Vector{Monomial}
+monoms(V, d::Int) -> Vector{Monomial}
+monoms(V, rg::UnitRangeInt) -> Vector{Monomial}
 ```
 List of all monomials in the variables V up to degree d of from degree d1 to d2,
 ordered by increasing degree.
 """
-function monoms(V::Vector{PolyVar{true}}, rg::UnitRange{Int64})
+function monoms(V::Vector{PolyVar{true}}, rg::UnitRange{Int})
     L = DynamicPolynomials.Monomial{true}[]
     for i in rg
         append!(L, DynamicPolynomials.monomials(V,i))
@@ -126,12 +126,12 @@ end
 #-----------------------------------------------------------------------
 """
 ```
-monoms(V, d::Int64) -> Vector{Monomial}
+monoms(V, d::Int) -> Vector{Monomial}
 ```
 List of all monomials in the variables V up to degree d of from degree d1 to d2,
 ordered by increasing degree.
 """
-function monoms(V::Vector{PolyVar{true}}, d ::Int64)
+function monoms(V::Vector{PolyVar{true}}, d ::Int)
     if (d>0)
         monoms(V,0:d)
     else
@@ -186,7 +186,7 @@ function LinearAlgebra.norm(p::Polynomial{B,T}, x::Float64) where {B,T}
     r
 end
 
-function LinearAlgebra.norm(pol::Polynomial{B,T}, p::Int64=2) where {B,T}
+function LinearAlgebra.norm(pol::Polynomial{B,T}, p::Int=2) where {B,T}
     r=sum(abs(t.α)^p for t in pol)
     exp(log(r)/p)
 end
@@ -198,7 +198,7 @@ end
 function matrixof(P::Vector{Polynomial{B,C}}, L ) where {B,C}
 
     M = fill(zero(C), length(P), length(L))
-    idx = Dict{Monomial{true},Int64}()
+    idx = Dict{Monomial{true},Int}()
     for i in 1:length(L)
         idx[L[i]] = i
     end

--- a/src/series.jl
+++ b/src/series.jl
@@ -134,7 +134,7 @@ function norm(s::Series{C,M}, x::Float64) where {C,M}
     r
 end
 
-function norm(s::Series{C,M}, p::Int64=2) where {C,M}
+function norm(s::Series{C,M}, p::Int=2) where {C,M}
     r = zero(C)
     for (m, c) in s
         r += abs(c)^p
@@ -277,7 +277,7 @@ end
 #----------------------------------------------------------------------
 """
 ```
-maxdegree(σ::Series) -> Int64
+maxdegree(σ::Series) -> Int
 ```
 Maximal degree of the moments defined in the series `σ`.
 """
@@ -430,7 +430,7 @@ function (|)(sigma::Series{C,M}, p::P) where {C,M, P<:AbstractPolynomial}
     return r
 end
 #----------------------------------------------------------------------
-function Base.truncate(s::Series{C,M}, d::Int64) where {C,M}
+function Base.truncate(s::Series{C,M}, d::Int) where {C,M}
     r = Series{C,M}()
     for (m,c) in s
         if degree(m)<= d
@@ -512,7 +512,7 @@ end
 """
  Compute the truncated primitive ``\\int_{x_{i}} s_{| x_{i+1}=0, ...x_n=0}''
 """
-function integrate(s::Series{C,M}, X, i::Int64) where {C,M}
+function integrate(s::Series{C,M}, X, i::Int) where {C,M}
     r = Series{C,M}()
     for (m,c) in s
         if i==length(X) || max(exponentvect(m,X[i+1:end])...) == 0


### PR DESCRIPTION
For 32-bit architectures, `Int` is an alias to `Int32` as integers default to `Int32`. With the current implementation, you get MethodError with 32-bit since you expect `Int64` at many places. This PR changes the `Int64` to `Int` to fix this.